### PR TITLE
Change require to remove deprecation notice

### DIFF
--- a/lib/dhasher.rb
+++ b/lib/dhasher.rb
@@ -1,4 +1,4 @@
-require 'RMagick'
+require 'rmagick'
 
 class DHasher
 


### PR DESCRIPTION
Requiring `RMagick` is now deprecated, this fixes that so any users using this gem don't have deprecation notices. 